### PR TITLE
MPDX-6728: Group Score Card Report

### DIFF
--- a/app/assets/stylesheets/stats.css
+++ b/app/assets/stylesheets/stats.css
@@ -1,3 +1,7 @@
+.mui-container {
+  margin-bottom: 2em;
+}
+
 .m-top-0 {
   margin-top: 0;
 }
@@ -34,4 +38,8 @@ table {
 
 .cell-data--bold {
   font-weight: bold;
+}
+
+.form-inputs {
+  margin: 1em;
 }

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -24,9 +24,8 @@ class StatsController < ApplicationController
     @data = {}
     params[:stat_ids].each do |stat_id|
       params[:stat_id] = stat_id
-      # use loader.load_account_list to pull person name and figure out how to add it into data 
-      # so you can pass it to be used by AccountListGroupStatsTable 
-      @data[stat_id] = loader.load_stats(:group)
+      name = loader.load_account_list["attributes"]["name"]
+      @data[name] = loader.load_stats(:group)
     end
     @table = AccountListGroupStatsTable.new(@data).table(:group)
   end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -7,7 +7,6 @@ class StatsController < ApplicationController
   end
 
   def weekly
-    binding.pry
     @account_list = loader.load_account_list
     @data = loader.load_stats(:weekly)
     @table = AccountListStatsTable.new(@data).table(:weekly)
@@ -25,6 +24,7 @@ class StatsController < ApplicationController
     # add logic you'd need to handle multiple people
     # only use :monthly 
     # may need a new view apart from app/views/stats/show.html.erb
+    render :show # maybe create new view called group_score_card.html.erb
   end
 
 

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -7,6 +7,7 @@ class StatsController < ApplicationController
   end
 
   def weekly
+    binding.pry
     @account_list = loader.load_account_list
     @data = loader.load_stats(:weekly)
     @table = AccountListStatsTable.new(@data).table(:weekly)
@@ -19,6 +20,13 @@ class StatsController < ApplicationController
     @table = AccountListStatsTable.new(@data).table(:monthly)
     render :show
   end
+
+  def group_score_card
+    # add logic you'd need to handle multiple people
+    # only use :monthly 
+    # may need a new view apart from app/views/stats/show.html.erb
+  end
+
 
   private
 

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -21,17 +21,22 @@ class StatsController < ApplicationController
   end
 
   def group_score_card
-    # add logic you'd need to handle multiple people
-    # only use :monthly 
-    # may need a new view apart from app/views/stats/show.html.erb
-    render :show # maybe create new view called group_score_card.html.erb
+    @data = {}
+    params[:stat_ids].each do |stat_id|
+      params[:stat_id] = stat_id
+      # use loader.load_account_list to pull person name and figure out how to add it into data 
+      # so you can pass it to be used by AccountListGroupStatsTable 
+      @data[stat_id] = loader.load_stats(:group)
+    end
+    @table = AccountListGroupStatsTable.new(@data).table(:group)
   end
 
 
   private
 
   def loader
-    @loader ||= AccountListStatsLoader.new(account_list_id: params[:stat_id],
+    # removed ||= because group_score_card wasn't pulling new data for multiple users
+    @loader = AccountListStatsLoader.new(account_list_id: params[:stat_id],
                                            token: session[:mpdx_token],
                                            env: params[:env])
   end

--- a/app/lib/account_list_group_stats_table.rb
+++ b/app/lib/account_list_group_stats_table.rb
@@ -7,6 +7,7 @@ class AccountListGroupStatsTable < AccountListStatsTable
   def table(type)
     rows = [
       name_header_row(type),
+      dates_header_row(type),
       main_header_row,
       newsletter_row(type),
       blank_row
@@ -24,22 +25,9 @@ class AccountListGroupStatsTable < AccountListStatsTable
     cells = [{text: "", colspan: "3"}]
 
     number_of_time_periods.times do |i|
-      cells << name_header_cell(i, type, i.even?)
+      color = i.even? ? :white : nil
+      cells << {text: @og_data.keys[i], colspan: "2", class: cell_class(color)}
     end
     {type: "header", cells: cells}
-  end
-
-  def name_header_cell(index, type, white)
-    attributes = @data[index]["attributes"]
-    text = nil
-    if type == :weekly
-      start_date = DateTime.parse(attributes["start_date"]).strftime("%b&nbsp;%d")
-      end_date = DateTime.parse(attributes["end_date"]).strftime("%b&nbsp;%d")
-      text = "#{start_date}-#{end_date}"
-    else
-      text = DateTime.parse(attributes["start_date"]).strftime("%b&nbsp;%Y")
-    end
-    color = white ? :white : nil
-    {text: text.html_safe, colspan: "2", class: cell_class(color)}
   end
 end

--- a/app/lib/account_list_group_stats_table.rb
+++ b/app/lib/account_list_group_stats_table.rb
@@ -1,0 +1,45 @@
+class AccountListGroupStatsTable < AccountListStatsTable
+  def initialize(data)
+    @og_data = data
+    @data = @og_data.map{|data| data[1]["data"]}.flatten
+  end
+
+  def table(type)
+    rows = [
+      name_header_row(type),
+      main_header_row,
+      newsletter_row(type),
+      blank_row
+    ]
+    rows += task_action_rows
+    rows << blank_row
+    rows += task_tags_rows
+    rows << totals_row(rows, type)
+    rows
+  end
+
+  private
+
+  def name_header_row(type)
+    cells = [{text: "", colspan: "3"}]
+
+    number_of_time_periods.times do |i|
+      cells << name_header_cell(i, type, i.even?)
+    end
+    {type: "header", cells: cells}
+  end
+
+  def name_header_cell(index, type, white)
+    attributes = @data[index]["attributes"]
+    text = nil
+    if type == :weekly
+      start_date = DateTime.parse(attributes["start_date"]).strftime("%b&nbsp;%d")
+      end_date = DateTime.parse(attributes["end_date"]).strftime("%b&nbsp;%d")
+      text = "#{start_date}-#{end_date}"
+    else
+      text = DateTime.parse(attributes["start_date"]).strftime("%b&nbsp;%Y")
+    end
+    color = white ? :white : nil
+    {text: text.html_safe, colspan: "2", class: cell_class(color)}
+  end
+end

--- a/app/lib/account_list_stats_loader.rb
+++ b/app/lib/account_list_stats_loader.rb
@@ -77,7 +77,7 @@ class AccountListStatsLoader
     if @env == :stage
       "https://api.stage.mpdx.org"
     else
-      "https://api.stage.mpdx.org" # use stage while developing "https://api.mpdx.org"
+      "https://api.mpdx.org"
     end
   end
 

--- a/app/lib/account_list_stats_loader.rb
+++ b/app/lib/account_list_stats_loader.rb
@@ -46,13 +46,13 @@ class AccountListStatsLoader
   end
 
   def tags_report(type)
-    range = "#{number_of_time_periods}#{type == :weekly ? "w" : "m"}"
+    range = "#{number_of_time_periods(type)}#{type == :weekly ? "w" : "m"}"
     url = "/api/v2/reports/tag_histories?"\
       "filter%5Baccount_list_id%5D=#{@account_list_id}&"\
       "filter%5Bassociation%5D=tasks&"\
       "filter%5Brange%5D=#{range}"
     json = mpdx_rest_get(url)
-    json["data"] = json["data"][0..(number_of_time_periods - 1)]
+    json["data"] = json["data"][0..(number_of_time_periods(type) - 1)]
     json
   end
 
@@ -64,8 +64,13 @@ class AccountListStatsLoader
     mpdx_rest_get(account_list_analytics_endpoint, account_list_analytics_params)
   end
 
-  def number_of_time_periods
-    5
+  def number_of_time_periods(type)
+    case type
+    when :weekly, :monthly
+      5
+    else
+      1
+    end
   end
 
   def url_host

--- a/app/lib/account_list_stats_loader.rb
+++ b/app/lib/account_list_stats_loader.rb
@@ -72,7 +72,7 @@ class AccountListStatsLoader
     if @env == :stage
       "https://api.stage.mpdx.org"
     else
-      "https://api.mpdx.org"
+      "https://api.stage.mpdx.org" # use stage while developing "https://api.mpdx.org"
     end
   end
 

--- a/app/lib/account_list_stats_table.rb
+++ b/app/lib/account_list_stats_table.rb
@@ -55,7 +55,7 @@ class AccountListStatsTable
 
   def newsletter_row(type)
     cells = [
-      {text: 'Last Prayer Letter (Put an "X" in week it was sent)'},
+      {text: 'Prayer Letter Sent'},
       {text: "Newsletter - Physical or Email"},
       {text: "25", class: data_class}
     ]
@@ -118,7 +118,7 @@ class AccountListStatsTable
   def totals_row(previous_rows, type)
     goal = goal(type)
     cells = [
-      {text: "#{type.capitalize} effort goal"},
+      {text: "Points Total"},
       {text: ""},
       {text: goal, class: data_class}
     ]
@@ -151,7 +151,7 @@ class AccountListStatsTable
     when :monthly
       800
     when :group
-      @data.count * 800
+      0
     end
   end
 

--- a/app/lib/account_list_stats_table.rb
+++ b/app/lib/account_list_stats_table.rb
@@ -116,7 +116,7 @@ class AccountListStatsTable
   end
 
   def totals_row(previous_rows, type)
-    goal = type == :weekly ? 200 : 800
+    goal = goal(type)
     cells = [
       {text: "#{type.capitalize} effort goal"},
       {text: ""},
@@ -142,6 +142,17 @@ class AccountListStatsTable
 
   def data_class(color = :gray, bold = false)
     "cell-data #{cell_class(color, bold)}"
+  end
+
+  def goal(type)
+    case type
+    when :weekly
+      200
+    when :monthly
+      800
+    when :group
+      @data.count * 800
+    end
   end
 
   def blank_row

--- a/app/lib/account_list_stats_table.rb
+++ b/app/lib/account_list_stats_table.rb
@@ -150,7 +150,7 @@ class AccountListStatsTable
       200
     when :monthly
       800
-    when :group
+    else
       0
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
     <script src="//cdn.muicss.com/mui-0.10.3/js/mui.min.js"></script>
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
-     <%= javascript_pack_tag 'application' %> 
+    <%= javascript_pack_tag 'application' %>
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,11 +13,7 @@
     <script src="//cdn.muicss.com/mui-0.10.3/js/mui.min.js"></script>
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%
-=begin%>
- <%= javascript_pack_tag 'application' %> 
-<%
-=end%>
+     <%= javascript_pack_tag 'application' %> 
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,11 @@
     <script src="//cdn.muicss.com/mui-0.10.3/js/mui.min.js"></script>
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%= javascript_pack_tag 'application' %>
+    <%
+=begin%>
+ <%= javascript_pack_tag 'application' %> 
+<%
+=end%>
   </head>
 
   <body>

--- a/app/views/stats/group_score_card.html.erb
+++ b/app/views/stats/group_score_card.html.erb
@@ -1,9 +1,5 @@
-<h2 class="m-bottom-0">Level of Effort Report for</h2>
-<%
-=begin%>
- <h1 class="m-top-0"><%= @account_list['attributes']['name'] %></h1> 
-<%
-=end%>
+<h2 class="m-bottom-0">Level of Effort Report for Group</h2>
+
 <p><%= link_to 'View a Different Account', stats_path(env: params[:env]) %></p>
 
 <table>

--- a/app/views/stats/group_score_card.html.erb
+++ b/app/views/stats/group_score_card.html.erb
@@ -1,0 +1,21 @@
+<h2 class="m-bottom-0">Level of Effort Report for</h2>
+<%
+=begin%>
+ <h1 class="m-top-0"><%= @account_list['attributes']['name'] %></h1> 
+<%
+=end%>
+<p><%= link_to 'View a Different Account', stats_path(env: params[:env]) %></p>
+
+<table>
+  <% @table.each do |row| %>
+  <tr>
+    <% row[:cells].each do |cell| %>
+    <% if row[:type] == 'header' %>
+    <th colspan="<%= cell[:colspan] %>" class="<%= cell[:class] %>"><%= cell[:text] %></th>
+    <% else %>
+    <td colspan="<%= cell[:colspan] %>" class="<%= cell[:class] %>"><%= cell[:text] %></td>
+    <% end %>
+    <% end %>
+  </tr>
+  <% end %>
+</table>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -18,9 +18,9 @@
 <%= form_with url: group_score_card_stats_path, method: :get do |form| %>
 
  <% @coaching_account_lists.each do |account_list| %>
-    <%= form.check_box :account_list_ids, {multiple: true}, account_list['id'], nil %>
-    <%= form.label :account_list_ids, "#{account_list['attributes']['name']}" %><br>
+    <%= form.check_box :stat_ids, {multiple: true}, account_list['id'], nil %>
+    <%= form.label :stat_ids, "#{account_list['attributes']['name']}" %><br>
   <% end %>  
-
+  <!-- don't forget to add in hidden field for :env -->
   <%= form.submit "View Report" %>
 <% end %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Pick an account</h1>
+<h1>Choose a Report</h1>
 
 <h2>Your Accounts:</h2>
 <ul>
@@ -7,21 +7,23 @@
   <% end %>
 </ul>
 
-<h2>Accounts You Coach:</h2>
+<h2>People You Coach:</h2>
 <ul>
   <% @coaching_account_lists.each do |account_list| %>
     <li><%= link_to account_list['attributes']['name'], stat_weekly_path(account_list['id'], env: params[:env]) %></li>
   <% end %>
 </ul>
 
-<h2>Group Scorecard:</h2>
-<%= form_with url: group_score_card_stats_path, method: :get do |form| %>
+<h2>Group Report:</h2>
+<i>Select the accounts to include in your group report.</i>
 
- <% @coaching_account_lists.each do |account_list| %>
-    <%= form.check_box :stat_ids, {multiple: true}, account_list['id'], nil %>
-    <%= form.label :stat_ids, "#{account_list['attributes']['name']}" %><br>
-    <%= form.hidden_field :env, value: params[:env] %>
-  <% end %>  
-  
+<%= form_with url: group_score_card_stats_path, method: :get do |form| %>
+ <div class="form-inputs">
+    <% @coaching_account_lists.each do |account_list| %>
+      <%= form.check_box :stat_ids, {multiple: true}, account_list['id'], nil %>
+      <%= form.label :stat_ids, "#{account_list['attributes']['name']}" %><br>
+      <%= form.hidden_field :env, value: params[:env] %>
+    <% end %>
+  </div>
   <%= form.submit "View Report" %>
 <% end %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -20,7 +20,8 @@
  <% @coaching_account_lists.each do |account_list| %>
     <%= form.check_box :stat_ids, {multiple: true}, account_list['id'], nil %>
     <%= form.label :stat_ids, "#{account_list['attributes']['name']}" %><br>
+    <%= form.hidden_field :env, value: params[:env] %>
   <% end %>  
-  <!-- don't forget to add in hidden field for :env -->
+  
   <%= form.submit "View Report" %>
 <% end %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -13,3 +13,12 @@
     <li><%= link_to account_list['attributes']['name'], stat_weekly_path(account_list['id'], env: params[:env]) %></li>
   <% end %>
 </ul>
+
+<h2>Accounts You Coach:</h2>
+<%= form_with url: stat_group_score_card_path, method: :get do |form| %>
+  <% @coaching_account_lists.each do |account_list| %>
+    <%= form.check_box :stat_id %>
+    <%= form.label :stat_id, "#{account_list['attributes']['name']}" %><br>
+  <% end %>
+  <%= form.submit "View Report" %>
+<% end %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -14,11 +14,13 @@
   <% end %>
 </ul>
 
-<h2>Accounts You Coach:</h2>
-<%= form_with url: stat_group_score_card_path, method: :get do |form| %>
-  <% @coaching_account_lists.each do |account_list| %>
-    <%= form.check_box :stat_id %>
-    <%= form.label :stat_id, "#{account_list['attributes']['name']}" %><br>
-  <% end %>
+<h2>Group Scorecard:</h2>
+<%= form_with url: group_score_card_stats_path, method: :get do |form| %>
+
+ <% @coaching_account_lists.each do |account_list| %>
+    <%= form.check_box :account_list_ids, {multiple: true}, account_list['id'], nil %>
+    <%= form.label :account_list_ids, "#{account_list['attributes']['name']}" %><br>
+  <% end %>  
+
   <%= form.submit "View Report" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   resources :stats, only: [:index] do
     get :weekly
     get :monthly
+    get :group_score_card
   end
 
   get "login", to: "login#create"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   resources :stats, only: [:index] do
     get :weekly
     get :monthly
-    get :group_score_card
+    collection do
+      get :group_score_card
+    end
   end
 
   get "login", to: "login#create"


### PR DESCRIPTION
Stakeholders requested a view where they can select staff to see a side-by-side scorecard for the different individuals. To accomplish this I added the following:

- A new form to allow customized selecting of individuals to display in group scorecard.
- A new controller method on the stats controller passing a new type `:group` to differentiate this logic from the logic using `weekly` or `monthly`.
- A new subclass of `account_list_stats_table` called `account_list_group_stats_table` that adds some customized features for the group scorecard.
- A new view for group_scorecard.
- Additional code to hopefully help the logic flow be clearly understandable when creating the group scorecard.