### PR TITLE
MPDX-7362: EMF Report Date Selector

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -22,6 +22,8 @@ class StatsController < ApplicationController
 
   def group_score_card
     @data = {}
+    params[:stat_ids] = JSON.parse(params[:stat_ids]) if params[:stat_ids].instance_of?(String)
+
     params[:stat_ids].each do |stat_id|
       params[:stat_id] = stat_id
       name = loader.load_account_list["attributes"]["name"]

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -25,7 +25,8 @@ class StatsController < ApplicationController
     params[:stat_ids].each do |stat_id|
       params[:stat_id] = stat_id
       name = loader.load_account_list["attributes"]["name"]
-      @data[name] = loader.load_stats(:group)
+      target_date = params[:target_date].to_date
+      @data[name] = loader.load_stats(:group, target_date)
     end
     @table = AccountListGroupStatsTable.new(@data).table(:group)
   end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,5 +1,5 @@
 class StatsController < ApplicationController
-  before_action :ensure_mpdx_active
+  before_action :ensure_mpdx_active, :target_date
 
   def index
     @user_account_lists = loader.load_user_ccount_lists
@@ -15,7 +15,7 @@ class StatsController < ApplicationController
 
   def monthly
     @account_list = loader.load_account_list
-    @data = loader.load_stats(:monthly)
+    @data = loader.load_stats(:monthly, @target_date)
     @table = AccountListStatsTable.new(@data).table(:monthly)
     render :show
   end
@@ -27,8 +27,7 @@ class StatsController < ApplicationController
     params[:stat_ids].each do |stat_id|
       params[:stat_id] = stat_id
       name = loader.load_account_list["attributes"]["name"]
-      target_date = params[:target_date].to_date
-      @data[name] = loader.load_stats(:group, target_date)
+      @data[name] = loader.load_stats(:group, @target_date)
     end
     @table = AccountListGroupStatsTable.new(@data).table(:group)
   end
@@ -40,6 +39,10 @@ class StatsController < ApplicationController
     @loader = AccountListStatsLoader.new(account_list_id: params[:stat_id],
                                            token: session[:mpdx_token],
                                            env: params[:env])
+  end
+
+  def target_date
+    @target_date = params[:target_date]&.to_date || Date.today
   end
 
   def ensure_mpdx_active

--- a/app/lib/account_list_stats_loader.rb
+++ b/app/lib/account_list_stats_loader.rb
@@ -91,7 +91,7 @@ class AccountListStatsLoader
     if @env == :stage
       "https://api.stage.mpdx.org"
     else
-      "https://api.stage.mpdx.org" # "https://api.mpdx.org"
+      "https://api.mpdx.org"
     end
   end
 

--- a/app/lib/account_list_stats_loader.rb
+++ b/app/lib/account_list_stats_loader.rb
@@ -91,7 +91,7 @@ class AccountListStatsLoader
     if @env == :stage
       "https://api.stage.mpdx.org"
     else
-      "https://api.mpdx.org"
+      "https://api.stage.mpdx.org" # "https://api.mpdx.org"
     end
   end
 

--- a/app/lib/account_list_stats_loader.rb
+++ b/app/lib/account_list_stats_loader.rb
@@ -5,8 +5,8 @@ class AccountListStatsLoader
     @env = env.presence&.to_sym || :prod
   end
 
-  def load_stats(type)
-    tags_data = tags_report(type)
+  def load_stats(type, target_date = Date.today)
+    tags_data = tags_report(type, target_date)
     json = {}
     json["data"] = tags_data["data"].map do |tag_data_row|
       data_range = "#{tag_data_row["attributes"]["start_date"]}..#{tag_data_row["attributes"]["end_date"]}"
@@ -45,8 +45,8 @@ class AccountListStatsLoader
     data
   end
 
-  def tags_report(type)
-    range = "#{number_of_time_periods(type)}#{type == :weekly ? "w" : "m"}"
+  def tags_report(type, target_date)
+    range = "#{number_of_intervals_between_now_and_target_date(type, target_date)}#{type == :weekly ? "w" : "m"}"
     url = "/api/v2/reports/tag_histories?"\
       "filter%5Baccount_list_id%5D=#{@account_list_id}&"\
       "filter%5Bassociation%5D=tasks&"\
@@ -54,6 +54,20 @@ class AccountListStatsLoader
     json = mpdx_rest_get(url)
     json["data"] = json["data"][0..(number_of_time_periods(type) - 1)]
     json
+  end
+
+  def number_of_intervals_between_now_and_target_date(type, target_date)
+    # This calculates # of months between today and target_date (1 added at end because report includes current month)
+    target_difference = (Date.today.year * 12 + Date.today.month) - (target_date.year * 12 + target_date.month) + 1
+
+    case type
+    when :weekly
+      5
+    when :monthly
+      (target_difference if target_difference > 5) || 5
+    else
+      target_difference
+    end
   end
 
   def account_list_analytics(date_range)

--- a/app/views/stats/group_score_card.html.erb
+++ b/app/views/stats/group_score_card.html.erb
@@ -2,6 +2,16 @@
 
 <p><%= link_to 'View a Different Account', stats_path(env: params[:env]) %></p>
 
+<%= form_with url: group_score_card_stats_path, method: :get do |form| %>
+ <div class="form-inputs">
+    <%= form.label :target_date, "Select Month:" %>
+    <%= form.select :target_date, (0..11).map{ |i| "#{Date::MONTHNAMES[(Date.today - i.month).month]} #{(Date.today-i.month).year}" } %>
+    <%= form.hidden_field :stat_ids, value: "#{params[:stat_ids]}" %>
+    <%= form.hidden_field :env, value: params[:env] %>
+  </div>
+  <%= form.submit "View Report" %>
+<% end %>
+
 <table>
   <% @table.each do |row| %>
   <tr>

--- a/app/views/stats/group_score_card.html.erb
+++ b/app/views/stats/group_score_card.html.erb
@@ -5,11 +5,11 @@
 <%= form_with url: group_score_card_stats_path, method: :get do |form| %>
  <div class="form-inputs">
     <%= form.label :target_date, "Select Month:" %>
-    <%= form.select :target_date, (0..11).map{ |i| "#{Date::MONTHNAMES[(Date.today - i.month).month]} #{(Date.today-i.month).year}" } %>
+    <%= form.select :target_date, (0..11).map{ |i| "#{Date::MONTHNAMES[(Date.today - i.month).month]} #{(Date.today-i.month).year}" }, { selected: params[:target_date] } %>
     <%= form.hidden_field :stat_ids, value: "#{params[:stat_ids]}" %>
     <%= form.hidden_field :env, value: params[:env] %>
+    <%= form.submit "View Report" %>
   </div>
-  <%= form.submit "View Report" %>
 <% end %>
 
 <table>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -22,8 +22,10 @@
     <% @coaching_account_lists.each do |account_list| %>
       <%= form.check_box :stat_ids, {multiple: true}, account_list['id'], nil %>
       <%= form.label :stat_ids, "#{account_list['attributes']['name']}" %><br>
-      <%= form.hidden_field :env, value: params[:env] %>
     <% end %>
+    <%= form.label :target_date, "Select Month:" %>
+    <%= form.select :target_date, (0..11).map{ |i| "#{Date::MONTHNAMES[(Date.today - i.month).month]} #{(Date.today-i.month).year}" } %>
+    <%= form.hidden_field :env, value: params[:env] %>
   </div>
   <%= form.submit "View Report" %>
 <% end %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -18,14 +18,12 @@
 <i>Select the accounts to include in your group report.</i>
 
 <%= form_with url: group_score_card_stats_path, method: :get do |form| %>
- <div class="form-inputs">
-    <% @coaching_account_lists.each do |account_list| %>
-      <%= form.check_box :stat_ids, {multiple: true}, account_list['id'], nil %>
-      <%= form.label :stat_ids, "#{account_list['attributes']['name']}" %><br>
+  <div class="form-inputs">
+      <% @coaching_account_lists.each do |account_list| %>
+        <%= form.check_box :stat_ids, {multiple: true}, account_list['id'], nil %>
+        <%= form.label :stat_ids, "#{account_list['attributes']['name']}" %><br>
     <% end %>
-    <%= form.label :target_date, "Select Month:" %>
-    <%= form.select :target_date, (0..11).map{ |i| "#{Date::MONTHNAMES[(Date.today - i.month).month]} #{(Date.today-i.month).year}" } %>
     <%= form.hidden_field :env, value: params[:env] %>
-  </div>
   <%= form.submit "View Report" %>
+  </div>
 <% end %>

--- a/app/views/stats/show.html.erb
+++ b/app/views/stats/show.html.erb
@@ -4,6 +4,18 @@
 <p>
   <%= link_to 'Weekly', stat_weekly_path(params[:stat_id], env: params[:env]) %> -
   <%= link_to 'Monthly', stat_monthly_path(params[:stat_id], env: params[:env]) %>
+
+  <% if params[:action] == "monthly" %>
+    <%= form_with url: stat_monthly_path, method: :get do |form| %>
+      <div class="form-inputs">
+        <%= form.label :target_date, "Select Month:" %>
+        <%= form.select :target_date, (0..11).map{ |i| "#{Date::MONTHNAMES[(Date.today - i.month).month]} #{(Date.today-i.month).year}" }, { selected: params[:target_date] } %>
+        <%= form.hidden_field :stat_id, value: "#{params[:stat_ids]}" %>
+        <%= form.hidden_field :env, value: params[:env] %>
+        <%= form.submit "View Report" %>
+      </div>
+    <% end %>
+  <% end %>
 </p>
 
 <table>


### PR DESCRIPTION
To add a date selector I had to get a little fancy. The `tag_histories` report doesn't accept a traditional date range (to my knowledge). Instead of a normal date range, it accepts an integer and a letter: d (day), m (month), y(year). For example `4m`, this tells the report to go pull the past 4 months of data. The report also pulls start and end dates for each month and these dates are used by this code base to make a followup call for tasks completed within those dates.

So I was left manipulating the integer letter combo. I did this by writing a method (`number_of_intervals_between_now_and_target_date`) to calculate the number of months between the current month and desired month so I knew what the integer needed to be in the URL. This then provided me with the data to display in the score cards.
